### PR TITLE
refact: Add .dockerignore.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gitignore
+Dockerfile
+README.md
+docker-compose.yml


### PR DESCRIPTION
When working with Docker, one of the most important and often overlooked files is .dockerignore. This file plays a crucial role in optimizing the Docker image build process by preventing unnecessary files from being included.

What is .dockerignore?
The .dockerignore file works similarly to .gitignore, being used to specify which files and directories should be ignored when building a Docker image. This is crucial to ensuring that the image is as lightweight as possible and does not contain unnecessary files, such as local dependencies, development environment-specific configuration files, and other temporary artifacts.